### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/aomarai/compstat/security/code-scanning/6](https://github.com/aomarai/compstat/security/code-scanning/6)

To address this issue, add a `permissions` block to the workflow file limiting the GITHUB_TOKEN to the minimal required privileges. The recommended minimal starting point is `contents: read`, which allows reading repository contents without writing. This can be placed either globally (at the root, next to `name:` or `on:`), which applies to all jobs unless overridden, or individually for each job (less preferable when all jobs can inherit the same least privilege).  
**Best fix:**  
Add the following block near the top (after `name: CI` and before `on:`):  
```yaml
permissions:
  contents: read
```

This change ensures that all jobs only have read access to repository contents. If in the future, a job needs extra permission (e.g., `pull-requests: write`), it can be given individually.  
**Files/regions to change:**  
Edit `.github/workflows/ci.yml`, adding the block after the workflow `name:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add a permissions block with contents: read at the root of the CI workflow file to enforce least-privilege access