### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,5 +1,8 @@
 name: Nightly Benchmark
 
+permissions:
+  contents: read
+
 on:
   schedule:
     # Run at 2 AM UTC every day
@@ -23,6 +26,8 @@ jobs:
   benchmark:
     name: Run Comprehensive Benchmark
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
@@ -202,6 +207,9 @@ jobs:
     needs: benchmark
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/aomarai/compstat/security/code-scanning/5](https://github.com/aomarai/compstat/security/code-scanning/5)

To fix the problem, add an explicit `permissions` block to the workflow, either at the root, so all jobs inherit it, or per job, customizing their access to the minimal required. The permissions should follow the principle of least privilege: only grant write access to the `contents` scope for jobs that need to commit/push, and to `issues` for jobs that might create issues. Other jobs should have (at least) `contents: read`. 

- At minimum, add `permissions: contents: read` at the root of `.github/workflows/benchmark.yml`. 
- For jobs that require extra permissions (such as creating issues, as in `benchmark-comparison`), add (or override) `permissions` for that job to include `issues: write`.
- The `benchmark` job needs `contents: write` if it performs git pushes.
- Update lines after the workflow `name` and/or job definitions to add these blocks.

No new methods or imports are required; only workflow YAML policy blocks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Add explicit, least-privilege permissions to the nightly benchmark workflow to satisfy code scanning requirements

Bug Fixes:
- Fix code scanning alert by specifying a default contents: read permission at the workflow root

CI:
- Grant contents: write to the benchmark job for pushing changes
- Grant contents: read and issues: write to the comparison job for issue creation